### PR TITLE
feat: replacing override_json (OCI-2349)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -133,7 +133,7 @@ resource "random_password" "referer" {
 data "aws_iam_policy_document" "s3_origin" {
   count = local.s3_origin_enabled ? 1 : 0
 
-  override_json = local.override_policy
+  override_policy_documents = [local.override_policy]
 
   statement {
     sid = "S3GetObjectForCloudFront"
@@ -163,7 +163,7 @@ data "aws_iam_policy_document" "s3_origin" {
 data "aws_iam_policy_document" "s3_website_origin" {
   count = local.website_enabled ? 1 : 0
 
-  override_json = local.override_policy
+  override_policy_documents = [local.override_policy]
 
   statement {
     sid = "S3GetObjectForCloudFront"


### PR DESCRIPTION
## Info

* replaced deprecated override json.
* updating this so we can update the terraform aws provider version to > v5.  Afterwards we'll update this module (cloudfront-s3-cdn) to the latest cloud posse module.

## References

OCI-2349
